### PR TITLE
Fix mask within union

### DIFF
--- a/src/struct.ts
+++ b/src/struct.ts
@@ -106,6 +106,7 @@ export class Struct<T = unknown, S = unknown> {
     value: unknown,
     options: {
       coerce?: boolean
+      mask?: boolean
       message?: string
     } = {}
   ): [StructError, undefined] | [undefined, T] {

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -216,6 +216,8 @@ export function validate<T, S>(
 export type Context = {
   branch: Array<any>
   path: Array<any>
+  mask: boolean
+  coerce: boolean
 }
 
 /**

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -499,9 +499,9 @@ export function union<A extends AnyStruct, B extends AnyStruct[]>(
   return new Struct({
     type: 'union',
     schema: null,
-    coercer(value) {
+    coercer(value, ctx) {
       for (const S of Structs) {
-        const [error, coerced] = S.validate(value, { coerce: true })
+        const [error, coerced] = S.validate(value, ctx)
         if (!error) {
           return coerced
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,7 +131,7 @@ export function* run<T, S>(
   } = {}
 ): IterableIterator<[Failure, undefined] | [undefined, T]> {
   const { path = [], branch = [value], coerce = false, mask = false } = options
-  const ctx: Context = { path, branch }
+  const ctx: Context = { path, branch, mask, coerce }
 
   if (coerce) {
     value = struct.coercer(value, ctx)

--- a/test/index.ts
+++ b/test/index.ts
@@ -8,6 +8,7 @@ import {
   // eslint-disable-next-line import/named
   Context,
   create as createValue,
+  mask as maskValue,
   deprecated,
   StructError,
 } from '../src'
@@ -38,14 +39,17 @@ describe('superstruct', () => {
 
         for (const name of tests) {
           const module = require(resolve(testsDir, name))
-          const { Struct, data, create, only, skip, output, failures } = module
+          const { Struct, data, create, mask, only, skip, output, failures } =
+            module
           const run = only ? it.only : skip ? it.skip : it
           run(name, () => {
             let actual
             let err
 
             try {
-              if (create) {
+              if (mask) {
+                actual = maskValue(data, Struct)
+              } else if (create) {
                 actual = createValue(data, Struct)
               } else {
                 assertValue(data, Struct)

--- a/test/validation/union/masking-object.ts
+++ b/test/validation/union/masking-object.ts
@@ -1,0 +1,13 @@
+import { union, string, number, object } from '../../../src'
+
+const A = string()
+
+const B = object({ a: number() })
+
+export const Struct = union([A, B])
+
+export const data = { a: 5, b: 5 }
+
+export const output = { a: 5 }
+
+export const mask = true

--- a/test/validation/union/no-coercion.ts
+++ b/test/validation/union/no-coercion.ts
@@ -1,0 +1,36 @@
+import { union, string, number, defaulted } from '../../../src'
+
+const A = defaulted(string(), 'foo')
+const B = number()
+
+export const Struct = union([A, B])
+
+export const data = undefined
+
+export const failures = [
+  {
+    value: undefined,
+    type: 'union',
+    refinement: undefined,
+    path: [],
+    branch: [data],
+  },
+  {
+    value: undefined,
+    type: 'string',
+    refinement: undefined,
+    path: [],
+    branch: [data],
+  },
+  {
+    value: undefined,
+    type: 'number',
+    refinement: undefined,
+    path: [],
+    branch: [data],
+  },
+]
+
+// For this test, we explicitly do not want to run coercion
+
+export const create = false


### PR DESCRIPTION
This PR fixes the issue of masking not being respected for objects within a union. This was fixed via extending the Context type with coerce/mask options, which is subsequently passed through to the validate method.

Changelog:

- Add masking option for validation tests
- Add union tests for masking inner objects
- Add mask option to validate struct method
- Add no coercions test for union
- Add mask and coerce to Context type
- Pass context to validate in inner structs within a union
